### PR TITLE
Implement a bunch of minor fixes

### DIFF
--- a/.github/utils/cookiecutter_values.yaml
+++ b/.github/utils/cookiecutter_values.yaml
@@ -3,6 +3,7 @@ default_context:
   project_slug: "oteapi-ci"
   package_name: "oteapi_ci"
   author: "Team4.0"
+  username: "TEAM4-0"
   organization: "SINTEF"
   email: "Team4.0@SINTEF.no"
   version: "0.0.1"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ These should be **updated** to **your specific needs** according to the strategy
 The ones that are not used should be deleted.
 
 It is **important** to update the [`setup.cfg`](%7B%7B%20cookiecutter.project_slug%20%7D%7D/setup.cfg) according to the updated strategies in order for the strategies to be importable through OTE-API Core.
+Please ensure to either uncomment the strategies as they are needed or remove them altogether if they are not needed.
 
 ## Usage
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,9 +3,10 @@
   "project_slug": "oteapi-myplugin",
   "package_name": "{{ cookiecutter.project_slug|lower|replace('-', '_') }}",
   "author": "Firstname Lastname",
+  "username": "GitHubLabBitBucketUsername",
   "organization": "SINTEF",
   "email": "firstname.lastname@{{ cookiecutter.organization }}.org",
   "version": "0.0.1",
-  "git_url": "https://github.com/{{ cookiecutter.author|replace(' ', '') }}/{{ cookiecutter.project_slug }}",
+  "git_url": "https://github.com/{{ cookiecutter.username }}/{{ cookiecutter.project_slug }}",
   "year": "2022"
 }

--- a/{{ cookiecutter.project_slug }}/.gitignore
+++ b/{{ cookiecutter.project_slug }}/.gitignore
@@ -10,3 +10,6 @@ __pycache__
 # Coverage
 .coverage
 htmlcov
+
+# Documentation
+site/

--- a/{{ cookiecutter.project_slug }}/mkdocs.yml
+++ b/{{ cookiecutter.project_slug }}/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: "{{ cookiecutter.project_name }}"
 site_description: Documentation for the {{ cookiecutter.project_name }} package
-site_url: https://{{ cookiecutter.author|replace(' ', '') }}.github.io/{{ cookiecutter.project_slug }}
+site_url: https://{{ cookiecutter.username }}.github.io/{{ cookiecutter.project_slug }}
 copyright: Copyright &copy; 2022 {{ cookiecutter.organization }}
 
 theme:
@@ -25,7 +25,7 @@ edit_uri: ""
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/{{ cookiecutter.author|replace(' ', '') }}
+      link: https://github.com/{{ cookiecutter.username }}
       name: "{{ cookiecutter.author }} on GitHub"
   version:
     provider: mike
@@ -83,7 +83,7 @@ plugins:
             - import os
             - os.environ["MKDOCS_BUILD"] = "1"
       watch:
-        - {{ cookiecutter.package_name }}
+        - "{{ cookiecutter.package_name }}"
   - awesome-pages
 
 nav:

--- a/{{ cookiecutter.project_slug }}/mkdocs.yml
+++ b/{{ cookiecutter.project_slug }}/mkdocs.yml
@@ -83,7 +83,7 @@ plugins:
             - import os
             - os.environ["MKDOCS_BUILD"] = "1"
       watch:
-        - oteapi
+        - {{ cookiecutter.package_name }}
   - awesome-pages
 
 nav:

--- a/{{ cookiecutter.project_slug }}/requirements_docs.txt
+++ b/{{ cookiecutter.project_slug }}/requirements_docs.txt
@@ -3,4 +3,4 @@ mike~=1.1
 mkdocs~=1.2
 mkdocs-awesome-pages-plugin~=2.6
 mkdocs-material~=8.1
-mkdocstrings~=0.17.0
+mkdocstrings[python]~=0.17.0

--- a/{{ cookiecutter.project_slug }}/setup.cfg
+++ b/{{ cookiecutter.project_slug }}/setup.cfg
@@ -1,13 +1,15 @@
+# Either uncomment the strategy lines as they are needed
+# or remove them if they are not needed.
 [options.entry_points]
 oteapi.download =
-  {{ cookiecutter.package_name }}.fileDEMO = {{ cookiecutter.package_name }}.strategies.download:DemoFileStrategy
+  # {{ cookiecutter.package_name }}.fileDEMO = {{ cookiecutter.package_name }}.strategies.download:DemoFileStrategy
 oteapi.filter =
-  {{ cookiecutter.package_name }}.filter/DEMO = {{ cookiecutter.package_name }}.strategies.filter:DemoFilter
+  # {{ cookiecutter.package_name }}.filter/DEMO = {{ cookiecutter.package_name }}.strategies.filter:DemoFilter
 oteapi.mapping =
-  {{ cookiecutter.package_name }}.mapping/DEMO = {{ cookiecutter.package_name }}.strategies.mapping:DemoMappingStrategy
+  # {{ cookiecutter.package_name }}.mapping/DEMO = {{ cookiecutter.package_name }}.strategies.mapping:DemoMappingStrategy
 oteapi.parse =
-  {{ cookiecutter.package_name }}.text/jsonDEMO = {{ cookiecutter.package_name }}.strategies.parse:DemoJSONDataParseStrategy
+  # {{ cookiecutter.package_name }}.text/jsonDEMO = {{ cookiecutter.package_name }}.strategies.parse:DemoJSONDataParseStrategy
 oteapi.resource =
-  {{ cookiecutter.package_name }}.DEMO-access-service = {{ cookiecutter.package_name }}.strategies.resource:DemoResourceStrategy
+  # {{ cookiecutter.package_name }}.DEMO-access-service = {{ cookiecutter.package_name }}.strategies.resource:DemoResourceStrategy
 oteapi.transformation =
-  {{ cookiecutter.package_name }}.script/DEMO = {{ cookiecutter.package_name }}.strategies.transformation:DummyTransformationStrategy
+  # {{ cookiecutter.package_name }}.script/DEMO = {{ cookiecutter.package_name }}.strategies.transformation:DummyTransformationStrategy


### PR DESCRIPTION
Closes #23 
Fixes #26 
Fixes #27 
Closes #28

Also adds the `python` extra for `mkdocstrings`, using the new Python handler for retrieving Python doc strings for the MkDocs framework and API reference section.