### PR TITLE
Update requirements.txt

### DIFF
--- a/{{ cookiecutter.project_slug }}/requirements.txt
+++ b/{{ cookiecutter.project_slug }}/requirements.txt
@@ -1,1 +1,1 @@
-oteapi-core==0.0.5
+oteapi-core>=0.0.6

--- a/{{ cookiecutter.project_slug }}/requirements.txt
+++ b/{{ cookiecutter.project_slug }}/requirements.txt
@@ -1,1 +1,1 @@
-oteapi-core>=0.0.6
+oteapi-core>=0.0.6,<1


### PR DESCRIPTION
We don't want the plugins to (unnecessary) specify an exact version dependency of oteapi-core, since that could easy create incompatibilities which would prohibit using different plugins together.