### PR TITLE
Use the latest SINTEF/ci-cd pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
   # The project's documentation can be found at:
   # https://SINTEF.github.io/ci-cd/
   - repo: https://github.com/SINTEF/ci-cd
-    rev: v2.6.0
+    rev: v2.7.1
     hooks:
     - id: docs-api-reference
       args:
@@ -88,6 +88,8 @@ repos:
       - "--replacement=(setup.cfg),({{ cookiecutter.scm_url }}/blob/main/setup.cfg)"
     - id: update-pyproject
       stages: [manual]
+      verbose: true
       args:
       - "--root-repo-path={{ cookiecutter.project_slug }}"
       - "--ignore=dependency-name=oteapi-core...versions=>=1"
+      - "--skip-unnormalized-python-package-names"


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
With the --skip-unnormalized-python-package-names option to succeed, even when it cannot read the cookiecutter variables.

Also make the hook verbose.

I have tested this locally by running `pre-commit run --all-files --hook-stage manual`, seeing that the `pyproject.toml` file under the generated package is indeed updated correctly.

Fixes #205 

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
