### PR TITLE
Use `pip-audit` instead of `safety`

### DIFF
--- a/.github/utils/requirements.txt
+++ b/.github/utils/requirements.txt
@@ -1,3 +1,2 @@
 cookiecutter~=2.6
 flit~=3.12
-pip-audit~=2.9

--- a/.github/utils/requirements.txt
+++ b/.github/utils/requirements.txt
@@ -1,3 +1,3 @@
 cookiecutter~=2.6
 flit~=3.12
-safety~=3.3
+pip-audit~=2.9

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -56,8 +56,8 @@ jobs:
       run: pre-commit run --all-files
       working-directory: ./oteapi-ci
 
-    - name: Run safety
-      run: pip freeze | safety check --stdin
+    - name: Run pip-audit
+      uses: pypa/gh-action-pip-audit@v1.1.0
 
     - name: Build docs
       run: mkdocs build --strict
@@ -67,11 +67,11 @@ jobs:
       run: flit build
       working-directory: ./oteapi-ci
 
-  safety:
+  pip-audit:
     # Do not use SINTEF/ci-cd, since it requires the root repository to be installable
     # as a package.
     runs-on: ubuntu-latest
-    name: safety
+    name: pip-audit
 
     steps:
     - name: Checkout repository
@@ -88,5 +88,5 @@ jobs:
         pip install -U setuptools wheel
         pip install -r requirements.txt -r .github/utils/requirements.txt
 
-    - name: Run safety
-      run: pip freeze | safety check --stdin
+    - name: Run pip-audit
+      uses: pypa/gh-action-pip-audit@v1.1.0

--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -69,9 +69,9 @@ There are still some last things to do to ensure you have a nice CI/CD setup.
      - Pull requests with at least 1 reviewer approval.
      - Check success for the CI tests:
 
-       - 'External / Run \`pylint\` & \`safety\`'
        - 'External / Build distribution package'
        - 'External / Build Documentation'
+       - 'pip-audit'
        - 'pytest (linux-py3.10)'
        - 'pytest (windows-py3.10)'
        - 'pre-commit.ci - pr'

--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci_tests.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci_tests.yml
@@ -19,10 +19,8 @@ jobs:
       run_pre-commit: false
 
       # pylint & safety
-      python_version_pylint_safety: "3.10"
-
       run_pylint: false
-      run_safety: true
+      run_safety: false
 
       # Build package
       run_build_package: true
@@ -45,6 +43,28 @@ jobs:
         (LICENSE),(LICENSE.md)
         (compose.yml),({{ cookiecutter.scm_url }}/blob/main/compose.yml)
         (pyproject.toml),({{ cookiecutter.scm_url }}/blob/main/pyproject.toml)
+
+  pip-audit:
+    name: pip-audit
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U setuptools wheel
+        pip install -e .[dev]
+
+    - name: Run pip-audit
+      uses: pypa/gh-action-pip-audit@v1.1.0
 
   pytest:{% raw %}
     name: pytest (${{ matrix.os[1] }}-py${{ matrix.python-version }})


### PR DESCRIPTION
# Description
<!-- Summary of change, including the issue to be addressed. -->
Following similar changes in other OTE repositories.

## AI Summary

This pull request replaces the use of `safety` with `pip-audit` for dependency vulnerability checks across the CI/CD pipeline. The most important changes include updating workflow files, removing `safety` from dependencies, and modifying project templates to reflect the switch.

### CI/CD Workflow Updates:
* Replaced the `safety` job with a `pip-audit` job in `.github/workflows/ci_tests.yml`, using the `pypa/gh-action-pip-audit@v1.1.0` GitHub Action for dependency vulnerability checks. [[1]](diffhunk://#diff-bf607a21ebbd18b3f436cc9fac6937d9c8839c33ae022cb29c2bddd873f470ebL59-R60) [[2]](diffhunk://#diff-bf607a21ebbd18b3f436cc9fac6937d9c8839c33ae022cb29c2bddd873f470ebL70-R74) [[3]](diffhunk://#diff-bf607a21ebbd18b3f436cc9fac6937d9c8839c33ae022cb29c2bddd873f470ebL91-R92)
* Added a new `pip-audit` job definition in the `{{ cookiecutter.project_slug }}/.github/workflows/ci_tests.yml` template, ensuring it aligns with the updated CI/CD setup.

### Dependency Updates:
* Removed `safety` from `.github/utils/requirements.txt` to eliminate its use as a dependency.

### Template and Documentation Adjustments:
* Updated `hooks/post_gen_project.sh` to replace references to `safety` with `pip-audit` in CI test success criteria.
* Modified the `run_safety` configuration in the `ci_tests.yml` template to disable `safety` checks.

## Type of change
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
